### PR TITLE
fix: remove call to l() function in module name

### DIFF
--- a/crisp.php
+++ b/crisp.php
@@ -36,7 +36,7 @@ class Crisp extends Module
 
     public function __construct()
     {
-        $this->name = $this->l('crisp');
+        $this->name = 'crisp';
         $this->displayName = $this->l('Crisp - Live chat & AI Chatbot');
         $this->author = 'Crisp IM';
         $this->version = '1.1.1';


### PR DESCRIPTION
Causes error in /classes/Translate.php - substr(): Passing null to parameter #1 ($string) of type string is deprecated